### PR TITLE
Update PAL Linux GPIO buffer max length values

### DIFF
--- a/pal/linux/pal_gpio.c
+++ b/pal/linux/pal_gpio.c
@@ -54,7 +54,7 @@
 static int
 GPIOExport(int pin)
 {
-#define BUFFER_MAX 3
+#define BUFFER_MAX 4
 	char buffer[BUFFER_MAX];
 	ssize_t bytes_written;
 	int fd;
@@ -95,7 +95,7 @@ GPIODirection(int pin, int dir)
 {
 	static const char s_directions_str[]  = "in\0out";
 
-#define DIRECTION_MAX 35
+#define DIRECTION_MAX 34
 	char path[DIRECTION_MAX];
 	int fd;
 

--- a/pal/linux/pal_linux.h
+++ b/pal/linux/pal_linux.h
@@ -44,7 +44,7 @@
 
 #define HIGH 1
 #define LOW 0
-typedef uint8_t gpio_pin_t;
+typedef uint16_t gpio_pin_t;
 
 /** @brief PAL I2C context structure */
 typedef struct pal_linux


### PR DESCRIPTION
Change define directive preprocessor values to pilot a GPIO identified by a number up to three digits.