### PR TITLE
Cleanup Linux PAL

### DIFF
--- a/pal/linux/pal_linux.h
+++ b/pal/linux/pal_linux.h
@@ -55,4 +55,9 @@ typedef struct pal_linux
     void * upper_layer_event_handler;
 } pal_linux_t;
 
+typedef struct pal_linux_gpio {
+    gpio_pin_t pin_nr;
+    int fd;
+} pal_linux_gpio_t;
+
 #endif

--- a/pal/linux/pal_os_event.c
+++ b/pal/linux/pal_os_event.c
@@ -118,8 +118,8 @@ void pal_os_event_register_callback_oneshot(register_callback callback,
 	freq_nanosecs = time_us * 1000;
 	its.it_value.tv_sec = freq_nanosecs / 1000000000;
 	its.it_value.tv_nsec = freq_nanosecs % 1000000000;
-	its.it_interval.tv_sec = its.it_value.tv_sec;
-	its.it_interval.tv_nsec = its.it_value.tv_nsec;
+	its.it_interval.tv_sec = 0;
+	its.it_interval.tv_nsec = 0;
 	
 	if (timer_settime(timerid, 0, &its, NULL) == -1)
 	{

--- a/pal/linux/target/rpi3/pal_ifx_i2c_config.c
+++ b/pal/linux/target/rpi3/pal_ifx_i2c_config.c
@@ -43,8 +43,8 @@
 
 pal_linux_t linux_events = {0};
 
-gpio_pin_t gpio_pin_vdd = 27;
-gpio_pin_t gpio_pin_reset = 17;
+#define GPIO_PIN_VDD 27
+#define GPIO_PIN_RESET 4
 
 /**
  * \brief PAL I2C configuration for OPTIGA. 
@@ -61,13 +61,16 @@ pal_i2c_t optiga_pal_i2c_context_0 =
     NULL
 };
 
+static struct pal_linux_gpio pin_reset = {GPIO_PIN_RESET, -1};
+static struct pal_linux_gpio pin_vdd = {GPIO_PIN_VDD, -1};
+
 /**
 * \brief PAL vdd pin configuration for OPTIGA. 
  */
 pal_gpio_t optiga_vdd_0 =
 {
     // Platform specific GPIO context for the pin used to toggle Vdd.
-    (void*)&gpio_pin_vdd 
+    (void*)&pin_vdd
 };
 
 /**
@@ -76,7 +79,7 @@ pal_gpio_t optiga_vdd_0 =
 pal_gpio_t optiga_reset_0 =
 {
     // Platform specific GPIO context for the pin used to toggle Reset.
-    (void*)&gpio_pin_reset 
+    (void*)&pin_reset
 };
 
 /**

--- a/pal/linux/target/rpi3/pal_ifx_i2c_config.c
+++ b/pal/linux/target/rpi3/pal_ifx_i2c_config.c
@@ -44,7 +44,7 @@
 pal_linux_t linux_events = {0};
 
 #define GPIO_PIN_VDD 27
-#define GPIO_PIN_RESET 4
+#define GPIO_PIN_RESET 17
 
 /**
  * \brief PAL I2C configuration for OPTIGA. 


### PR DESCRIPTION
This contains the following fixes:

- make `GPIOWrite(...)` signal-safe, because the event timer executes in the signal context
- store the file descriptor in the gpio structure to avoid the overhead of opening the gpio pin before every write
- switch the event timer to single shot mode to avoid continously executing the event handler
- use `clock_nanosleep` over `usleep` to make the delay function signal safe