### PR TITLE
Change in pal_os_event.c for Zephyr PAL and clean up

### DIFF
--- a/examples/authenticate_chip/example_authenticate_chip.c
+++ b/examples/authenticate_chip/example_authenticate_chip.c
@@ -36,7 +36,7 @@
 #include "optiga/common/AuthLibSettings.h"
 #include "pal_crypt.h"
 
-///size of public key for NIST-P256
+///Size of public key for NIST-P256
 #define LENGTH_PUB_KEY_NISTP256     0x41
 
 ///Length of R and S vector
@@ -54,7 +54,7 @@
 // Length of SH256
 #define LENGTH_SHA256			32
 
-///size of end entity certificate of OPTIGA™ Trust X
+///Size of end entity certificate of OPTIGA™ Trust X
 #define LENGTH_OPTIGA_CERT          512
 
 #ifdef MODULE_ENABLE_ONE_WAY_AUTH
@@ -132,7 +132,7 @@ static optiga_lib_status_t __get_chip_cert(uint16_t cert_oid,
 			break;
 		}
 
-		//Get end entity device certificate
+		// Get end entity device certificate
 		status = optiga_util_read_data(cert_oid, 0, p_tmp_cert_pointer, p_cert_size);
 		if(OPTIGA_LIB_SUCCESS != status)
 		{
@@ -201,7 +201,7 @@ static optiga_lib_status_t __authenticate_chip(uint8_t* p_pubkey, uint16_t pubke
 
     do
     {
-        //Get PwChallengeLen byte random stream
+        // Get PwChallengeLen byte random stream
         status = pal_crypt_random(LENGTH_CHALLENGE, random);
         if(OPTIGA_LIB_SUCCESS != status)
         {
@@ -215,7 +215,7 @@ static optiga_lib_status_t __authenticate_chip(uint8_t* p_pubkey, uint16_t pubke
             break;
         }
 
-		//Sign random with OPTIGA™ Trust X
+		// Sign random with OPTIGA™ Trust X
         status = optiga_crypt_ecdsa_sign(digest, LENGTH_SHA256,
 									     privkey_oid,
 										 signature, &signature_size);
@@ -225,7 +225,7 @@ static optiga_lib_status_t __authenticate_chip(uint8_t* p_pubkey, uint16_t pubke
             break;
         }
 
-		//Verify the signature on the random number by Security Chip
+		// Verify the signature on the random number by Security Chip
 		status = pal_crypt_verify_signature(p_pubkey, pubkey_size,
 				                            signature, signature_size,
 											digest, LENGTH_SHA256);
@@ -285,7 +285,7 @@ optiga_lib_status_t example_authenticate_chip(void)
 			break;
 		}
 
-		//Certificate verification
+		// Certificate verification
     	status = __authenticate_chip(chip_pubkey, chip_pubkey_size, chip_privkey_oid);
 		if(OPTIGA_LIB_SUCCESS != status)
 		{

--- a/examples/authenticate_chip/pal_crypt_mbedtls.c
+++ b/examples/authenticate_chip/pal_crypt_mbedtls.c
@@ -49,7 +49,7 @@
 #include "mbedtls/x509.h"
 #include "mbedtls/x509_crt.h"
 
-// MAximum size of the ssignature (for P256 0x40)
+// Maximum size of the signature (for P256 0x40)
 #define LENGTH_MAX_SIGNATURE				0x40
 
 mbedtls_entropy_context 					entropy;

--- a/examples/authenticate_chip/pal_crypt_mbedtls.c
+++ b/examples/authenticate_chip/pal_crypt_mbedtls.c
@@ -93,7 +93,7 @@ static int32_t __verify_ecc_signature(const uint8_t* p_pubkey, uint16_t pubkey_s
         mbedtls_ecp_point_read_binary(&grp, &Q, p_pk, pubkey_size);
 
         //Import the signature
-        asn1_to_ecdsa_rs(p_signature, signature_size, signature_rs, &signature_rs_size);
+        asn1_to_ecdsa_rs(p_signature, signature_size, signature_rs, signature_rs_size);
         mbedtls_mpi_read_binary(&r, signature_rs, LENGTH_MAX_SIGNATURE/2);
         mbedtls_mpi_read_binary(&s, signature_rs + LENGTH_MAX_SIGNATURE/2, LENGTH_MAX_SIGNATURE/2);
 

--- a/examples/mbedtls_port/trustx_ecdh.c
+++ b/examples/mbedtls_port/trustx_ecdh.c
@@ -24,7 +24,11 @@
 * @{
 */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
 
 #if defined(MBEDTLS_ECDH_C)
 

--- a/examples/mbedtls_port/trustx_ecdsa.c
+++ b/examples/mbedtls_port/trustx_ecdsa.c
@@ -24,7 +24,11 @@
 * @{
 */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
 
 #if defined(MBEDTLS_ECDSA_C)
 

--- a/pal/efm32pg_zephyr/pal_i2c.c
+++ b/pal/efm32pg_zephyr/pal_i2c.c
@@ -46,7 +46,6 @@
 /**********************************************************************************************************************
  * MACROS
  *********************************************************************************************************************/
-#define I2C_DEVICE_NAME     DT_ALIAS_I2C_0_LABEL
 #define SEM_INIT_VALUE      1
 #define SEM_MAX_VALUE       1
 #define SEM_TAKE_SUCCESS    0
@@ -54,6 +53,15 @@
 /*********************************************************************************************************************
  * LOCAL DATA
  *********************************************************************************************************************/
+/* context for i2c devices */
+typedef struct {
+    uint8_t  p_scl_io;
+    uint8_t  p_sda_io;
+    uint8_t  p_port;
+    uint8_t *p_port_name;
+    uint32_t p_bitrate;
+} i2c_ctx_t;
+
 /* Structure for holding I2C device context */
 struct device *p_i2c_dev;
 
@@ -88,7 +96,8 @@ K_SEM_DEFINE(i2c_bus_lock, SEM_INIT_VALUE, SEM_MAX_VALUE);
  */
 pal_status_t pal_i2c_init(const pal_i2c_t* p_i2c_context)
 {
-    p_i2c_dev = device_get_binding(I2C_DEVICE_NAME);
+    i2c_ctx_t *current_ctx = p_i2c_context->p_i2c_hw_config;
+    p_i2c_dev = device_get_binding(current_ctx->p_port_name);
 
     if (p_i2c_dev == 0) {
         return PAL_STATUS_FAILURE;
@@ -163,7 +172,6 @@ pal_status_t pal_i2c_write(pal_i2c_t *p_i2c_context, uint8_t *p_data,
     pal_status_t status;
     app_event_handler_t upper_layer_handler =
             (app_event_handler_t)p_i2c_context->upper_layer_event_handler;
-
 
     lock_result = k_sem_take(&i2c_bus_lock, K_NO_WAIT);
 

--- a/pal/efm32pg_zephyr/pal_ifx_i2c_config.c
+++ b/pal/efm32pg_zephyr/pal_ifx_i2c_config.c
@@ -46,15 +46,16 @@
 /**********************************************************************************************************************
  * MACROS
  *********************************************************************************************************************/
-/* I2C0 on stk3402a EXP header */
-#define I2C_SCL     DT_INST_0_SILABS_GECKO_I2C_LOCATION_SCL_2  /* 11 */
-#define I2C_SDA     DT_INST_0_SILABS_GECKO_I2C_LOCATION_SDA_2  /* 10 */
-#define I2C_PORT    2   /* Port C */
-#define I2C_FREQ_HZ DT_INST_0_SILABS_GECKO_I2C_CLOCK_FREQUENCY /* 100 000 Hz */
+/* Configuration for I2C device */
+#define I2C_SCL         DT_INST_0_SILABS_GECKO_I2C_LOCATION_SCL_2  /* 11 */
+#define I2C_SDA         DT_INST_0_SILABS_GECKO_I2C_LOCATION_SDA_2  /* 10 */
+#define I2C_PORT        DT_INST_0_SILABS_GECKO_I2C_LOCATION_SDA_1  /* Port C = 2 */
+#define I2C_DEVICE_NAME DT_INST_0_SILABS_GECKO_I2C_LABEL /* Device name for bind */
+#define I2C_FREQ_HZ     DT_INST_0_SILABS_GECKO_I2C_CLOCK_FREQUENCY /* 100 000 Hz */
 
 #define I2C_OPTIGA_ADDRESS 0x30
 
-/* GPIO on stk3402a EXP header */
+/* Configuration for GPIO device */
 #define VDD_PORT_NAME   DT_GPIO_GECKO_PORTB_NAME
 #define RST_PORT_NAME   DT_GPIO_GECKO_PORTA_NAME
 #define VDD_PIN         8   /* PB8 */
@@ -65,9 +66,10 @@
  *********************************************************************************************************************/
 /* context for i2c devices */
 typedef struct {
-    uint8_t  p_port;
     uint8_t  p_scl_io;
     uint8_t  p_sda_io;
+    uint8_t  p_port;
+    uint8_t *p_port_name;
     uint32_t p_bitrate;
 } i2c_ctx_t;
 
@@ -79,22 +81,23 @@ typedef struct {
     uint8_t         p_init_flag;
 } gpio_ctx_t;
 
-/* inicialize context for stk3402a I2C and GPIO on EXP header */
-i2c_ctx_t stk3402a_i2c_ctx = {
-    I2C_PORT,
+/* initialization of contexts */
+i2c_ctx_t i2c_ctx = {
     I2C_SCL,
     I2C_SDA,
+    I2C_PORT,
+    I2C_DEVICE_NAME,
     I2C_FREQ_HZ
 };
 
-gpio_ctx_t vdd_stk3402a_gpio_ctx = {
+gpio_ctx_t vdd_gpio_ctx = {
     VDD_PIN,
     NULL,
     VDD_PORT_NAME,
     0
 };
 
-gpio_ctx_t rst_stk3402a_gpio_ctx = {
+gpio_ctx_t rst_gpio_ctx = {
     RST_PIN,
     NULL,
     RST_PORT_NAME,
@@ -102,27 +105,25 @@ gpio_ctx_t rst_stk3402a_gpio_ctx = {
 };
 
 /*********************************************************************************************************************
- * Pal ifx i2c instance
- *********************************************************************************************************************/
+ * Pal ifx i2c instance *********************************************************************************************************************/
 /**
  * \brief PAL I2C configuration for OPTIGA.
  */
 pal_i2c_t optiga_pal_i2c_context_0 = {
-    (void*)&stk3402a_i2c_ctx,   /* context */
-    I2C_OPTIGA_ADDRESS,         /* address */
-    NULL,                       /* upper layer context */
-    NULL                        /* callback event handler */
+    (void*)&i2c_ctx,     /* context */
+    I2C_OPTIGA_ADDRESS,  /* address */
+    NULL,                /* upper layer context */
+    NULL                 /* callback event handler */
 };
 
 /*********************************************************************************************************************
- * PAL GPIO configurations defined for Pearl Gecko (efm32pg_stk3402a)
- *********************************************************************************************************************/
+ * PAL GPIO configurations *********************************************************************************************************************/
 /**
  * \brief PAL vdd pin configuration for OPTIGA.
  */
 pal_gpio_t optiga_vdd_0 = {
     /* platform specific GPIO context for the pin used to toggle Vdd */
-    (void*)&vdd_stk3402a_gpio_ctx
+    (void*)&vdd_gpio_ctx
 };
 
 /**
@@ -130,7 +131,7 @@ pal_gpio_t optiga_vdd_0 = {
  */
 pal_gpio_t optiga_reset_0 = {
     /* platform specific GPIO context for the pin used to toggle Reset */
-    (void*)&rst_stk3402a_gpio_ctx
+    (void*)&rst_gpio_ctx
 };
 
 /**


### PR DESCRIPTION
Hi,
+ changed way *pal_os_event.c* is working. 
Deleted thread that was taking care of taking callback function after accessing semaphore from timer. Right now this is done right away by timer callback after timer expire. 
Thanks for great idea @MarcDorner
+ More generic variables names, and moved all config defines in *pal_ifx_i2c_config.c*.
+ Implemented including of a mbedTLS config file in few files basing on *optigax-random.c*.
+ changed *asn1_to_ecdsa_rs* call in *pal_crypt_mbedtls.c* because of warning (not expecting pointer).
+ some clean up of code