### PR TITLE
Add Popcorn Computer's PocketP.C. i2c pal file

### DIFF
--- a/pal/linux/target/popcorncomputer/originalpopcorn/pal_ifx_i2c_config.c
+++ b/pal/linux/target/popcorncomputer/originalpopcorn/pal_ifx_i2c_config.c
@@ -1,0 +1,86 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2018 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Popcorn Computer
+*
+* \file pal_ifx_i2c_config.c
+*
+* \brief   This file implements platform abstraction layer configurations for ifx i2c protocol.
+*
+* \ingroup  grPAL
+* @{
+*/
+
+
+#include "optiga/pal/pal_gpio.h"
+#include "optiga/pal/pal_i2c.h"
+#include "optiga/ifx_i2c/ifx_i2c_config.h"
+
+#include "pal_linux.h"
+
+pal_linux_t linux_events = {0};
+
+#define GPIO_PIN_RESET 68
+
+/**
+ * \brief PAL I2C configuration for OPTIGA. 
+ */
+pal_i2c_t optiga_pal_i2c_context_0 =
+{
+    /// Pointer to I2C master platform specific context
+    (void*)&linux_events,
+    /// Slave address
+    0x30,
+    /// Upper layer context
+    NULL,
+    /// Callback event handler
+    NULL
+};
+
+static struct pal_linux_gpio pin_reset = {GPIO_PIN_RESET, -1};
+
+/**
+* \brief PAL vdd pin configuration for OPTIGA. 
+ */
+pal_gpio_t optiga_vdd_0 =
+{
+    // Platform specific GPIO context for the pin used to toggle Vdd.
+    (void*)NULL
+};
+
+/**
+ * \brief PAL reset pin configuration for OPTIGA.
+ */
+pal_gpio_t optiga_reset_0 =
+{
+    // Platform specific GPIO context for the pin used to toggle Reset.
+    (void*)&pin_reset
+};
+
+/**
+* @}
+*/
+

--- a/pal/linux/target/popcorncomputer/pocketpc/pal_ifx_i2c_config.c
+++ b/pal/linux/target/popcorncomputer/pocketpc/pal_ifx_i2c_config.c
@@ -1,0 +1,86 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2018 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Popcorn Computer
+*
+* \file pal_ifx_i2c_config.c
+*
+* \brief   This file implements platform abstraction layer configurations for ifx i2c protocol.
+*
+* \ingroup  grPAL
+* @{
+*/
+
+
+#include "optiga/pal/pal_gpio.h"
+#include "optiga/pal/pal_i2c.h"
+#include "optiga/ifx_i2c/ifx_i2c_config.h"
+
+#include "pal_linux.h"
+
+pal_linux_t linux_events = {0};
+
+#define GPIO_PIN_RESET 231
+
+/**
+ * \brief PAL I2C configuration for OPTIGA. 
+ */
+pal_i2c_t optiga_pal_i2c_context_0 =
+{
+    /// Pointer to I2C master platform specific context
+    (void*)&linux_events,
+    /// Slave address
+    0x30,
+    /// Upper layer context
+    NULL,
+    /// Callback event handler
+    NULL
+};
+
+static struct pal_linux_gpio pin_reset = {GPIO_PIN_RESET, -1};
+
+/**
+* \brief PAL vdd pin configuration for OPTIGA. 
+ */
+pal_gpio_t optiga_vdd_0 =
+{
+    // Platform specific GPIO context for the pin used to toggle Vdd.
+    (void*)NULL
+};
+
+/**
+ * \brief PAL reset pin configuration for OPTIGA.
+ */
+pal_gpio_t optiga_reset_0 =
+{
+    // Platform specific GPIO context for the pin used to toggle Reset.
+    (void*)&pin_reset
+};
+
+/**
+* @}
+*/
+


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Popcorn Computer sells open hardware single board computers and handheld Linux devices.
Pocket P.C. is an open hardware Linux handheld that was successfully crowdfunded. Pocket P.C. is the process of finalizing product development and preparing for mass production. Pocket P.C. integrates an Optiga Trust X IC and we intend on shipping units with the cli-optiga-trust-x utilities and source code. We are preparing to upstream our board config to buildroot for Pocket P.C. as well as a package config for cli-optiga-trust-x and i2c-utilities-optiga-trust. We would be appreciative if Infineon added our device's pal file to the official optiga-trust-x repository. As you can see, we have been actively improving the cli-optiga-trust-x software and already have submitted a number of PRs. We intend on submitting more PRs in the future. 

https://pocket.popcorncomputer.com/

Related Issue
https://github.com/Infineon/optiga-trust-x/issues/47
